### PR TITLE
Refine middleware wiring and port tests to PHPUnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,92 @@
-<p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400" alt="Laravel Logo"></a></p>
+# Tabungan App
 
-<p align="center">
-<a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/workflows/tests/badge.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/laravel/framework" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
-</p>
+Aplikasi tabungan sederhana berbasis Laravel 12 dengan fokus pada kemudahan pengelolaan setoran dan penarikan untuk satu rekening tabungan per pengguna. Seluruh antarmuka menggunakan TailwindCSS berbasis komponen Blade dan mendukung pencetakan struk transaksi.
 
-## About Laravel
+## Fitur Utama
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
+- Registrasi & login pengguna dengan pembuatan rekening otomatis pada login pertama.
+- Satu rekening tabungan per pengguna dengan nomor rekening unik.
+- Transaksi setoran dan penarikan dengan validasi saldo dan nominal minimal Rp1.000.
+- Riwayat transaksi lengkap dengan filter tipe dan rentang tanggal.
+- Dashboard saldo, ringkasan transaksi bulanan, dan daftar transaksi terbaru.
+- Halaman detail transaksi dan struk siap cetak (PDF/HTML fallback) lengkap dengan QR visual.
+- Kebijakan akses berbasis policy: pengguna hanya dapat melihat data miliknya.
+- Seeder demo dengan dua akun pengguna dan transaksi contoh.
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
+## Kebutuhan Sistem
 
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
+- PHP 8.2 atau lebih baru dengan ekstensi `bcmath` dan `intl`.
+- SQLite (default) atau MySQL untuk basis data.
+- Composer untuk manajemen dependensi PHP.
+- Node.js (opsional bila ingin menyalin aset statis sendiri, meskipun proyek ini menggunakan CDN Tailwind untuk kemudahan demo).
 
-## Learning Laravel
+## Instalasi & Setup
 
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
+1. **Clone repositori** dan masuk ke direktori proyek.
+2. **Pasang dependensi PHP** dan paket tambahan:
+   ```bash
+   composer install
+   composer require barryvdh/laravel-dompdf simplesoftwareio/simple-qrcode pestphp/pest --dev pestphp/pest-plugin-laravel --dev
+   ```
+   > Catatan: pada lingkungan tanpa akses ke GitHub, siapkan token OAuth GitHub agar proses install berhasil.
+3. **Salin berkas environment** dan buat key aplikasi:
+   ```bash
+   cp .env.example .env
+   php artisan key:generate
+   ```
+4. **Konfigurasi basis data** di `.env`. Secara default, aplikasi menggunakan SQLite. Untuk SQLite, cukup buat file kosong:
+   ```bash
+   touch database/database.sqlite
+   ```
+5. **Jalankan migrasi dan seeder demo**:
+   ```bash
+   php artisan migrate --seed
+   ```
+6. **(Opsional) Build aset front-end** bila ingin menghapus ketergantungan CDN:
+   ```bash
+   npm install
+   npm run build
+   ```
 
-You may also try the [Laravel Bootcamp](https://bootcamp.laravel.com), where you will be guided through building a modern Laravel application from scratch.
+## Menjalankan Aplikasi
 
-If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains thousands of video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
+```bash
+php artisan serve
+```
 
-## Laravel Sponsors
+Akses aplikasi melalui `http://localhost:8000`. Gunakan kredensial demo dari seeder:
 
-We would like to extend our thanks to the following sponsors for funding Laravel development. If you are interested in becoming a sponsor, please visit the [Laravel Partners program](https://partners.laravel.com).
+- Email: `demo@tabungan.test` — Password: `password`
+- Email: `demo2@tabungan.test` — Password: `password`
 
-### Premium Partners
+## Pengujian
 
-- **[Vehikl](https://vehikl.com)**
-- **[Tighten Co.](https://tighten.co)**
-- **[Kirschbaum Development Group](https://kirschbaumdevelopment.com)**
-- **[64 Robots](https://64robots.com)**
-- **[Curotec](https://www.curotec.com/services/technologies/laravel)**
-- **[DevSquad](https://devsquad.com/hire-laravel-developers)**
-- **[Redberry](https://redberry.international/laravel-development)**
-- **[Active Logic](https://activelogic.com)**
+Proyek ini menggunakan Pest. Setelah memasang dependensi dev, jalankan:
 
-## Contributing
+```bash
+php artisan test
+```
 
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
+Pengujian mencakup skenario utama: pembuatan rekening otomatis, setoran & penarikan, pembatasan akses data, serta endpoint struk.
 
-## Code of Conduct
+## Asumsi & Catatan
 
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
+- TailwindCSS dimuat via CDN untuk menyederhanakan setup demo. Gunakan Vite bila membutuhkan optimasi produksi.
+- Struk transaksi menggunakan DomPDF. Jika DomPDF belum terpasang, aksi pencetakan akan merender halaman HTML sebagai fallback.
+- QR code pada struk merupakan representasi visual berbasis hash nomor struk. Pasang `simple-qrcode` bila ingin menggunakan QR code standar.
+- Rate limit sederhana (`throttle:5,1`) diterapkan pada endpoint transaksi untuk mencegah spam.
+- Zona waktu aplikasi disetel ke `Asia/Jakarta` dan bahasa default `id`.
 
-## Security Vulnerabilities
+## Struktur Penting
 
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
+- `app/Actions`: logika bisnis terpisah untuk pembuatan rekening dan transaksi.
+- `app/Http/Controllers`: controller untuk dashboard, transaksi, dan autentikasi.
+- `app/Http/Requests`: validasi form setoran dan penarikan.
+- `app/Policies`: policy akses rekening dan transaksi.
+- `resources/views/components`: komponen Blade untuk card, button, badge, input uang, tabel, modal, dan layout.
+- `resources/views/transactions/receipt.blade.php`: template struk PDF/HTML.
+- `tests/`: pengujian fitur menggunakan Pest (tambahkan setelah memasang dependensi dev).
 
-## License
+## Lisensi
 
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+Proyek ini berlisensi MIT mengikuti lisensi standar Laravel.

--- a/app/Actions/CreateSavingsAccountForUser.php
+++ b/app/Actions/CreateSavingsAccountForUser.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\SavingsAccount;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class CreateSavingsAccountForUser
+{
+    public function handle(User $user): SavingsAccount
+    {
+        return DB::transaction(function () use ($user) {
+            /** @var SavingsAccount|null $account */
+            $account = $user->savingsAccount()->lockForUpdate()->first();
+
+            if ($account) {
+                return $account;
+            }
+
+            return $user->savingsAccount()->create([
+                'balance' => 0,
+            ]);
+        });
+    }
+}

--- a/app/Actions/GenerateReceiptPdf.php
+++ b/app/Actions/GenerateReceiptPdf.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Transaction;
+use Illuminate\Http\Response;
+
+class GenerateReceiptPdf
+{
+    public function handle(Transaction $transaction): Response
+    {
+        $data = [
+            'transaction' => $transaction,
+            'account' => $transaction->savingsAccount,
+            'user' => $transaction->savingsAccount->user,
+        ];
+
+        if (class_exists(\Barryvdh\DomPDF\Facade\Pdf::class)) {
+            $pdf = \Barryvdh\DomPDF\Facade\Pdf::loadView('transactions.receipt', $data)->setPaper('a5');
+
+            return $pdf->stream('receipt-'.$transaction->receipt_number.'.pdf');
+        }
+
+        return response()
+            ->view('transactions.receipt', $data)
+            ->header('Content-Type', 'text/html');
+    }
+}

--- a/app/Actions/PerformDeposit.php
+++ b/app/Actions/PerformDeposit.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class PerformDeposit
+{
+    public function __construct(
+        protected CreateSavingsAccountForUser $createSavingsAccountForUser
+    ) {}
+
+    public function handle(User $user, float $amount, ?string $note = null): Transaction
+    {
+        return DB::transaction(function () use ($user, $amount, $note) {
+            $this->createSavingsAccountForUser->handle($user);
+
+            $account = $user->savingsAccount()->lockForUpdate()->first();
+
+            $normalizedAmount = number_format($amount, 2, '.', '');
+            $newBalance = bcadd($account->balance, $normalizedAmount, 2);
+
+            $transaction = $account->transactions()->create([
+                'type' => Transaction::TYPE_DEPOSIT,
+                'amount' => $normalizedAmount,
+                'running_balance' => $newBalance,
+                'receipt_number' => $this->generateReceiptNumber(),
+                'note' => $note,
+            ]);
+
+            // Update saldo di akhir agar konsisten
+            $account->update(['balance' => $newBalance]);
+
+            return $transaction;
+        });
+    }
+
+    protected function generateReceiptNumber(): string
+    {
+        return 'TX-'.now('Asia/Jakarta')->format('Ymd').'-'.Str::upper(Str::random(6));
+    }
+}

--- a/app/Actions/PerformWithdrawal.php
+++ b/app/Actions/PerformWithdrawal.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+
+class PerformWithdrawal
+{
+    public function __construct(
+        protected CreateSavingsAccountForUser $createSavingsAccountForUser
+    ) {}
+
+    public function handle(User $user, float $amount, ?string $note = null): Transaction
+    {
+        return DB::transaction(function () use ($user, $amount, $note) {
+            $this->createSavingsAccountForUser->handle($user);
+
+            $account = $user->savingsAccount()->lockForUpdate()->first();
+
+            $normalizedAmount = number_format($amount, 2, '.', '');
+
+            if (bccomp($account->balance, $normalizedAmount, 2) < 0) {
+                throw new InvalidArgumentException('Saldo tidak mencukupi untuk penarikan.');
+            }
+
+            $newBalance = bcsub($account->balance, $normalizedAmount, 2);
+
+            $transaction = $account->transactions()->create([
+                'type' => Transaction::TYPE_WITHDRAWAL,
+                'amount' => $normalizedAmount,
+                'running_balance' => $newBalance,
+                'receipt_number' => $this->generateReceiptNumber(),
+                'note' => $note,
+            ]);
+
+            $account->update(['balance' => $newBalance]);
+
+            return $transaction;
+        });
+    }
+
+    protected function generateReceiptNumber(): string
+    {
+        return 'TX-'.now('Asia/Jakarta')->format('Ymd').'-'.Str::upper(Str::random(6));
+    }
+}

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Actions\CreateSavingsAccountForUser;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rules\Password;
+use Illuminate\View\View;
+
+class AuthController extends Controller
+{
+    public function __construct(protected CreateSavingsAccountForUser $createSavingsAccountForUser)
+    {
+    }
+
+    public function showLogin(): View
+    {
+        return view('auth.login');
+    }
+
+    public function login(Request $request): RedirectResponse
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        if (Auth::attempt($credentials, $request->boolean('remember'))) {
+            $request->session()->regenerate();
+            $this->createSavingsAccountForUser->handle($request->user());
+
+            return redirect()->intended(route('dashboard'));
+        }
+
+        return back()->withErrors([
+            'email' => 'Kredensial tidak valid.',
+        ])->onlyInput('email');
+    }
+
+    public function showRegister(): View
+    {
+        return view('auth.register');
+    }
+
+    public function register(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'max:255', 'unique:users,email'],
+            'password' => ['required', 'confirmed', Password::min(8)],
+        ]);
+
+        $user = User::create([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => Hash::make($data['password']),
+        ]);
+
+        Auth::login($user);
+
+        $this->createSavingsAccountForUser->handle($user);
+
+        return redirect()->route('dashboard');
+    }
+
+    public function logout(Request $request): RedirectResponse
+    {
+        Auth::guard()->logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect()->route('login')->with('status', 'Anda telah keluar.');
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Actions\CreateSavingsAccountForUser;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+
+class DashboardController extends Controller
+{
+    public function __construct(
+        protected CreateSavingsAccountForUser $createSavingsAccountForUser
+    ) {
+    }
+
+    public function __invoke(Request $request): View
+    {
+        $user = $request->user();
+        $account = $this->createSavingsAccountForUser->handle($user);
+
+        $recentTransactions = $account->transactions()
+            ->latest()
+            ->take(5)
+            ->get();
+
+        $monthlyTotal = $account->transactions()
+            ->whereBetween('created_at', [
+                now('Asia/Jakarta')->startOfMonth(),
+                now('Asia/Jakarta')->endOfMonth(),
+            ])->count();
+
+        return view('dashboard.index', [
+            'account' => $account,
+            'recentTransactions' => $recentTransactions,
+            'monthlyTotal' => $monthlyTotal,
+        ]);
+    }
+}

--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Actions\CreateSavingsAccountForUser;
+use App\Actions\GenerateReceiptPdf;
+use App\Actions\PerformDeposit;
+use App\Actions\PerformWithdrawal;
+use App\Http\Requests\StoreDepositRequest;
+use App\Http\Requests\StoreWithdrawalRequest;
+use App\Models\Transaction;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use InvalidArgumentException;
+
+class TransactionController extends Controller
+{
+    public function __construct(
+        protected PerformDeposit $performDeposit,
+        protected PerformWithdrawal $performWithdrawal,
+        protected GenerateReceiptPdf $generateReceiptPdf,
+        protected CreateSavingsAccountForUser $createSavingsAccountForUser,
+    ) {
+    }
+
+    public function index(Request $request): View
+    {
+        /** @var \App\Models\User $user */
+        $user = $request->user();
+        $account = $user->savingsAccount ?: $this->createSavingsAccountForUser->handle($user);
+
+        $query = $account->transactions()->latest();
+
+        $type = $request->filled('type') ? $request->string('type')->toString() : null;
+
+        if ($type) {
+            $query->where('type', $type);
+        }
+
+        if ($request->filled('from')) {
+            $query->whereDate('created_at', '>=', $request->date('from'));
+        }
+
+        if ($request->filled('to')) {
+            $query->whereDate('created_at', '<=', $request->date('to'));
+        }
+
+        /** @var LengthAwarePaginator $transactions */
+        $transactions = $query->paginate(10)->withQueryString();
+
+        return view('transactions.index', [
+            'account' => $account,
+            'transactions' => $transactions,
+            'filters' => [
+                'type' => $type,
+                'from' => $request->input('from'),
+                'to' => $request->input('to'),
+            ],
+        ]);
+    }
+
+    public function create(Request $request): View
+    {
+        $this->createSavingsAccountForUser->handle($request->user());
+
+        return view('transactions.create');
+    }
+
+    public function store(StoreDepositRequest $request): RedirectResponse
+    {
+        $user = $request->user();
+        $amount = (float) $request->input('amount');
+
+        $transaction = $this->performDeposit->handle($user, $amount, $request->input('note'));
+
+        return redirect()
+            ->route('transactions.show', $transaction)
+            ->with('status', 'Setoran berhasil disimpan.');
+    }
+
+    public function storeWithdrawal(StoreWithdrawalRequest $request): RedirectResponse
+    {
+        $user = $request->user();
+        $amount = (float) $request->input('amount');
+
+        try {
+            $transaction = $this->performWithdrawal->handle($user, $amount, $request->input('note'));
+        } catch (InvalidArgumentException $exception) {
+            return back()->withErrors(['amount' => $exception->getMessage()])->withInput();
+        }
+
+        return redirect()
+            ->route('transactions.show', $transaction)
+            ->with('status', 'Penarikan berhasil disimpan.');
+    }
+
+    public function show(Transaction $transaction): View
+    {
+        Gate::authorize('view', $transaction);
+
+        return view('transactions.show', [
+            'transaction' => $transaction,
+            'account' => $transaction->savingsAccount,
+        ]);
+    }
+
+    public function receipt(Transaction $transaction)
+    {
+        Gate::authorize('view', $transaction);
+
+        return $this->generateReceiptPdf->handle($transaction);
+    }
+}

--- a/app/Http/Requests/StoreDepositRequest.php
+++ b/app/Http/Requests/StoreDepositRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreDepositRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'amount' => ['required', 'numeric', 'min:1000', 'max:1000000000'],
+            'note' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreWithdrawalRequest.php
+++ b/app/Http/Requests/StoreWithdrawalRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreWithdrawalRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'amount' => ['required', 'numeric', 'min:1000', 'max:1000000000'],
+            'note' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Models/SavingsAccount.php
+++ b/app/Models/SavingsAccount.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
+
+class SavingsAccount extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'account_number',
+        'balance',
+    ];
+
+    protected $casts = [
+        'balance' => 'decimal:2',
+    ];
+
+    protected static function booted(): void
+    {
+        static::creating(function (SavingsAccount $account) {
+            if (! $account->account_number) {
+                $account->account_number = 'ACC-'.Str::upper(Str::random(10));
+            }
+        });
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function transactions(): HasMany
+    {
+        return $this->hasMany(Transaction::class);
+    }
+}

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Transaction extends Model
+{
+    use HasFactory;
+
+    public const TYPE_DEPOSIT = 'deposit';
+    public const TYPE_WITHDRAWAL = 'withdrawal';
+
+    protected $fillable = [
+        'savings_account_id',
+        'type',
+        'amount',
+        'running_balance',
+        'receipt_number',
+        'note',
+    ];
+
+    protected $casts = [
+        'amount' => 'decimal:2',
+        'running_balance' => 'decimal:2',
+    ];
+
+    public function savingsAccount(): BelongsTo
+    {
+        return $this->belongsTo(SavingsAccount::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,20 +2,21 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+// use Illuminate\Contracts\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
 class User extends Authenticatable
 {
-    /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory, Notifiable;
 
     /**
      * The attributes that are mass assignable.
      *
-     * @var list<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'name',
@@ -26,7 +27,7 @@ class User extends Authenticatable
     /**
      * The attributes that should be hidden for serialization.
      *
-     * @var list<string>
+     * @var array<int, string>
      */
     protected $hidden = [
         'password',
@@ -34,15 +35,22 @@ class User extends Authenticatable
     ];
 
     /**
-     * Get the attributes that should be cast.
+     * The attributes that should be cast.
      *
-     * @return array<string, string>
+     * @var array<string, string>
      */
-    protected function casts(): array
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+        'password' => 'hashed',
+    ];
+
+    public function savingsAccount(): HasOne
     {
-        return [
-            'email_verified_at' => 'datetime',
-            'password' => 'hashed',
-        ];
+        return $this->hasOne(SavingsAccount::class);
+    }
+
+    public function transactions(): HasManyThrough
+    {
+        return $this->hasManyThrough(Transaction::class, SavingsAccount::class);
     }
 }

--- a/app/Policies/SavingsAccountPolicy.php
+++ b/app/Policies/SavingsAccountPolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\SavingsAccount;
+use App\Models\User;
+
+class SavingsAccountPolicy
+{
+    public function view(User $user, SavingsAccount $account): bool
+    {
+        return $account->user_id === $user->id;
+    }
+
+    public function update(User $user, SavingsAccount $account): bool
+    {
+        return $this->view($user, $account);
+    }
+}

--- a/app/Policies/TransactionPolicy.php
+++ b/app/Policies/TransactionPolicy.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Transaction;
+use App\Models\User;
+
+class TransactionPolicy
+{
+    public function view(User $user, Transaction $transaction): bool
+    {
+        return $transaction->savingsAccount->user_id === $user->id;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,23 +2,27 @@
 
 namespace App\Providers;
 
+use App\Models\SavingsAccount;
+use App\Models\Transaction;
+use App\Policies\SavingsAccountPolicy;
+use App\Policies\TransactionPolicy;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
+use Carbon\Carbon;
 
 class AppServiceProvider extends ServiceProvider
 {
-    /**
-     * Register any application services.
-     */
     public function register(): void
     {
         //
     }
 
-    /**
-     * Bootstrap any application services.
-     */
     public function boot(): void
     {
-        //
+        Gate::policy(SavingsAccount::class, SavingsAccountPolicy::class);
+        Gate::policy(Transaction::class, TransactionPolicy::class);
+
+        Carbon::setLocale(config('app.locale'));
+        setlocale(LC_TIME, 'id_ID.UTF-8');
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -1,99 +1,21 @@
 <?php
 
 return [
-
-    /*
-    |--------------------------------------------------------------------------
-    | Application Name
-    |--------------------------------------------------------------------------
-    |
-    | This value is the name of your application, which will be used when the
-    | framework needs to place the application's name in a notification or
-    | other UI elements where an application name needs to be displayed.
-    |
-    */
-
-    'name' => env('APP_NAME', 'Laravel'),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Application Environment
-    |--------------------------------------------------------------------------
-    |
-    | This value determines the "environment" your application is currently
-    | running in. This may determine how you prefer to configure various
-    | services the application utilizes. Set this in your ".env" file.
-    |
-    */
+    'name' => env('APP_NAME', 'Tabungan'),
 
     'env' => env('APP_ENV', 'production'),
 
-    /*
-    |--------------------------------------------------------------------------
-    | Application Debug Mode
-    |--------------------------------------------------------------------------
-    |
-    | When your application is in debug mode, detailed error messages with
-    | stack traces will be shown on every error that occurs within your
-    | application. If disabled, a simple generic error page is shown.
-    |
-    */
-
     'debug' => (bool) env('APP_DEBUG', false),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Application URL
-    |--------------------------------------------------------------------------
-    |
-    | This URL is used by the console to properly generate URLs when using
-    | the Artisan command line tool. You should set this to the root of
-    | the application so that it's available within Artisan commands.
-    |
-    */
 
     'url' => env('APP_URL', 'http://localhost'),
 
-    /*
-    |--------------------------------------------------------------------------
-    | Application Timezone
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify the default timezone for your application, which
-    | will be used by the PHP date and date-time functions. The timezone
-    | is set to "UTC" by default as it is suitable for most use cases.
-    |
-    */
+    'timezone' => env('APP_TIMEZONE', 'Asia/Jakarta'),
 
-    'timezone' => 'UTC',
+    'locale' => env('APP_LOCALE', 'id'),
 
-    /*
-    |--------------------------------------------------------------------------
-    | Application Locale Configuration
-    |--------------------------------------------------------------------------
-    |
-    | The application locale determines the default locale that will be used
-    | by Laravel's translation / localization methods. This option can be
-    | set to any locale for which you plan to have translation strings.
-    |
-    */
+    'fallback_locale' => env('APP_FALLBACK_LOCALE', 'id'),
 
-    'locale' => env('APP_LOCALE', 'en'),
-
-    'fallback_locale' => env('APP_FALLBACK_LOCALE', 'en'),
-
-    'faker_locale' => env('APP_FAKER_LOCALE', 'en_US'),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Encryption Key
-    |--------------------------------------------------------------------------
-    |
-    | This key is utilized by Laravel's encryption services and should be set
-    | to a random, 32 character string to ensure that all encrypted values
-    | are secure. You should do this prior to deploying the application.
-    |
-    */
+    'faker_locale' => env('APP_FAKER_LOCALE', 'id_ID'),
 
     'cipher' => 'AES-256-CBC',
 
@@ -105,22 +27,8 @@ return [
         ),
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Maintenance Mode Driver
-    |--------------------------------------------------------------------------
-    |
-    | These configuration options determine the driver used to determine and
-    | manage Laravel's "maintenance mode" status. The "cache" driver will
-    | allow maintenance mode to be controlled across multiple machines.
-    |
-    | Supported drivers: "file", "cache"
-    |
-    */
-
     'maintenance' => [
         'driver' => env('APP_MAINTENANCE_DRIVER', 'file'),
         'store' => env('APP_MAINTENANCE_STORE', 'database'),
     ],
-
 ];

--- a/database/factories/SavingsAccountFactory.php
+++ b/database/factories/SavingsAccountFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SavingsAccount;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<SavingsAccount>
+ */
+class SavingsAccountFactory extends Factory
+{
+    protected $model = SavingsAccount::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'account_number' => 'ACC-'.Str::upper(Str::random(10)),
+            'balance' => 0,
+        ];
+    }
+}

--- a/database/factories/TransactionFactory.php
+++ b/database/factories/TransactionFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SavingsAccount;
+use App\Models\Transaction;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Transaction>
+ */
+class TransactionFactory extends Factory
+{
+    protected $model = Transaction::class;
+
+    public function definition(): array
+    {
+        $type = $this->faker->randomElement([
+            Transaction::TYPE_DEPOSIT,
+            Transaction::TYPE_WITHDRAWAL,
+        ]);
+
+        $amount = $this->faker->numberBetween(10_000, 500_000);
+
+        return [
+            'savings_account_id' => SavingsAccount::factory(),
+            'type' => $type,
+            'amount' => $amount,
+            'running_balance' => $type === Transaction::TYPE_WITHDRAWAL
+                ? $this->faker->numberBetween(0, $amount)
+                : $amount,
+            'receipt_number' => 'TX-'.$this->faker->date('Ymd').'-'.Str::upper(Str::random(6)),
+            'note' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/migrations/2024_01_01_000000_create_savings_accounts_table.php
+++ b/database/migrations/2024_01_01_000000_create_savings_accounts_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('savings_accounts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->string('account_number')->unique();
+            $table->decimal('balance', 18, 2)->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('savings_accounts');
+    }
+};

--- a/database/migrations/2024_01_01_000001_create_transactions_table.php
+++ b/database/migrations/2024_01_01_000001_create_transactions_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('transactions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('savings_account_id')->constrained()->cascadeOnDelete();
+            $table->enum('type', ['deposit', 'withdrawal']);
+            $table->decimal('amount', 18, 2);
+            $table->decimal('running_balance', 18, 2);
+            $table->string('receipt_number')->unique();
+            $table->string('note')->nullable();
+            $table->timestamps();
+
+            $table->index(['savings_account_id', 'type']);
+            $table->index('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('transactions');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,22 +2,56 @@
 
 namespace Database\Seeders;
 
+use App\Actions\CreateSavingsAccountForUser;
+use App\Actions\PerformDeposit;
+use App\Actions\PerformWithdrawal;
 use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\App;
 
 class DatabaseSeeder extends Seeder
 {
-    /**
-     * Seed the application's database.
-     */
     public function run(): void
     {
-        // User::factory(10)->create();
+        $createAccount = App::make(CreateSavingsAccountForUser::class);
+        $performDeposit = App::make(PerformDeposit::class);
+        $performWithdrawal = App::make(PerformWithdrawal::class);
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        $users = [
+            [
+                'name' => 'Demo Nasabah',
+                'email' => 'demo@tabungan.test',
+                'password' => bcrypt('password'),
+            ],
+            [
+                'name' => 'Demo Kedua',
+                'email' => 'demo2@tabungan.test',
+                'password' => bcrypt('password'),
+            ],
+        ];
+
+        foreach ($users as $userData) {
+            /** @var User $user */
+            $user = User::updateOrCreate(
+                ['email' => $userData['email']],
+                $userData,
+            );
+
+            $createAccount->handle($user);
+
+            for ($i = 0; $i < 5; $i++) {
+                $amount = rand(100_000, 500_000);
+                $performDeposit->handle($user, $amount, 'Setoran demo #'.($i + 1));
+
+                if ($i % 2 === 0) {
+                    $withdrawAmount = rand(50_000, $amount - 10_000);
+                    try {
+                        $performWithdrawal->handle($user, $withdrawAmount, 'Penarikan demo #'.($i + 1));
+                    } catch (\InvalidArgumentException $e) {
+                        // abaikan bila saldo tidak cukup saat seeding
+                    }
+                }
+            }
+        }
     }
 }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,0 +1,21 @@
+<x-layouts.guest>
+    <form method="POST" action="{{ route('login') }}" class="space-y-4">
+        @csrf
+        <div>
+            <label for="email" class="mb-1 block text-sm font-medium text-slate-700">Email</label>
+            <input id="email" type="email" name="email" value="{{ old('email') }}" required autofocus class="w-full rounded-xl border border-slate-200 px-4 py-3 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200">
+        </div>
+        <div>
+            <label for="password" class="mb-1 block text-sm font-medium text-slate-700">Kata Sandi</label>
+            <input id="password" type="password" name="password" required class="w-full rounded-xl border border-slate-200 px-4 py-3 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200">
+        </div>
+        <div class="flex items-center justify-between text-sm text-slate-600">
+            <label class="inline-flex items-center gap-2">
+                <input type="checkbox" name="remember" class="rounded border-slate-300 text-blue-600 focus:ring-blue-500">
+                Ingat saya
+            </label>
+            <a href="{{ route('register') }}" class="font-semibold text-blue-600 hover:underline">Daftar akun</a>
+        </div>
+        <x-button type="submit" class="w-full justify-center">Masuk</x-button>
+    </form>
+</x-layouts.guest>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,0 +1,25 @@
+<x-layouts.guest>
+    <form method="POST" action="{{ route('register') }}" class="space-y-4">
+        @csrf
+        <div>
+            <label for="name" class="mb-1 block text-sm font-medium text-slate-700">Nama Lengkap</label>
+            <input id="name" type="text" name="name" value="{{ old('name') }}" required autofocus class="w-full rounded-xl border border-slate-200 px-4 py-3 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200">
+        </div>
+        <div>
+            <label for="email" class="mb-1 block text-sm font-medium text-slate-700">Email</label>
+            <input id="email" type="email" name="email" value="{{ old('email') }}" required class="w-full rounded-xl border border-slate-200 px-4 py-3 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200">
+        </div>
+        <div>
+            <label for="password" class="mb-1 block text-sm font-medium text-slate-700">Kata Sandi</label>
+            <input id="password" type="password" name="password" required class="w-full rounded-xl border border-slate-200 px-4 py-3 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200">
+        </div>
+        <div>
+            <label for="password_confirmation" class="mb-1 block text-sm font-medium text-slate-700">Konfirmasi Kata Sandi</label>
+            <input id="password_confirmation" type="password" name="password_confirmation" required class="w-full rounded-xl border border-slate-200 px-4 py-3 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200">
+        </div>
+        <div class="text-sm text-slate-600">
+            Sudah punya akun? <a href="{{ route('login') }}" class="font-semibold text-blue-600 hover:underline">Masuk di sini</a>.
+        </div>
+        <x-button type="submit" class="w-full justify-center">Daftar</x-button>
+    </form>
+</x-layouts.guest>

--- a/resources/views/components/badge.blade.php
+++ b/resources/views/components/badge.blade.php
@@ -1,0 +1,15 @@
+@props(['variant' => 'primary'])
+
+@php
+    $base = 'inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide';
+    $variants = [
+        'success' => 'bg-green-100 text-green-700',
+        'warning' => 'bg-yellow-100 text-yellow-700',
+        'info' => 'bg-blue-100 text-blue-700',
+    ];
+    $class = $base.' '.($variants[$variant] ?? $variants['info']);
+@endphp
+
+<span {{ $attributes->merge(['class' => $class]) }}>
+    {{ $slot }}
+</span>

--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -1,0 +1,38 @@
+@props([
+    'variant' => 'primary',
+    'type' => 'button',
+    'loading' => false,
+])
+
+@php
+    $base = 'inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2 font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-60 disabled:cursor-not-allowed';
+    $variants = [
+        'primary' => 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-200',
+        'secondary' => 'bg-slate-100 text-slate-700 hover:bg-slate-200 focus:ring-slate-200',
+        'danger' => 'bg-red-500 text-white hover:bg-red-600 focus:ring-red-200',
+    ];
+    $class = $base.' '.($variants[$variant] ?? $variants['primary']);
+    $tag = $attributes->has('href') ? 'a' : 'button';
+@endphp
+
+@if ($tag === 'a')
+    <a {{ $attributes->merge(['class' => $class]) }}>
+        @if($loading)
+            <svg class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+            </svg>
+        @endif
+        <span>{{ $slot }}</span>
+    </a>
+@else
+    <button type="{{ $type }}" {{ $attributes->merge(['class' => $class]) }} @disabled($loading)>
+        @if($loading)
+            <svg class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+            </svg>
+        @endif
+        <span>{{ $slot }}</span>
+    </button>
+@endif

--- a/resources/views/components/card.blade.php
+++ b/resources/views/components/card.blade.php
@@ -1,0 +1,3 @@
+<div {{ $attributes->merge(['class' => 'bg-white rounded-2xl shadow-md p-6']) }}>
+    {{ $slot }}
+</div>

--- a/resources/views/components/input-money.blade.php
+++ b/resources/views/components/input-money.blade.php
@@ -1,0 +1,34 @@
+@props([
+    'name',
+    'label' => null,
+    'value' => null,
+    'placeholder' => 'Masukkan nominal',
+])
+
+@php
+    $inputId = $attributes->get('id', $name.'-input');
+    $formatted = $value !== null ? number_format((float) $value, 2, ',', '.') : '';
+@endphp
+
+<div class="space-y-2" data-money-input>
+    @if($label)
+        <label for="{{ $inputId }}" class="block text-sm font-medium text-slate-700">{{ $label }}</label>
+    @endif
+    <div class="relative">
+        <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-slate-400">Rp</span>
+        <input
+            type="text"
+            id="{{ $inputId }}"
+            autocomplete="off"
+            inputmode="decimal"
+            data-money-display
+            class="w-full rounded-xl border border-slate-200 bg-white py-3 pl-10 pr-4 text-lg font-semibold text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            placeholder="{{ $placeholder }}"
+            value="{{ $formatted }}"
+        >
+        <input type="hidden" name="{{ $name }}" data-money-hidden value="{{ $value }}">
+    </div>
+    @error($name)
+        <p class="text-sm text-red-600">{{ $message }}</p>
+    @enderror
+</div>

--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="id" class="h-full bg-slate-100">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ config('app.name', 'Tabungan') }}</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography,forms"></script>
+    <link rel="preconnect" href="https://fonts.bunny.net">
+    <link href="https://fonts.bunny.net/css?family=inter:400,500,600,700" rel="stylesheet" />
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+    </style>
+</head>
+<body class="flex min-h-full flex-col">
+    <div class="flex-1">
+        <div class="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10">
+            <header class="flex flex-wrap items-center justify-between gap-4">
+                <div>
+                    <h1 class="text-2xl font-bold text-slate-900">{{ config('app.name', 'Tabungan') }}</h1>
+                    <p class="text-sm text-slate-500">Kelola tabungan Anda dengan mudah.</p>
+                </div>
+                <nav class="flex items-center gap-3 text-sm text-slate-600">
+                    <a href="{{ route('dashboard') }}" class="rounded-xl px-3 py-2 font-semibold hover:bg-white">Dashboard</a>
+                    <a href="{{ route('transactions.index') }}" class="rounded-xl px-3 py-2 font-semibold hover:bg-white">Transaksi</a>
+                    <form method="POST" action="{{ route('logout') }}" class="inline">
+                        @csrf
+                        <x-button type="submit" variant="secondary">Keluar</x-button>
+                    </form>
+                </nav>
+            </header>
+
+            @if (session('status'))
+                <div class="rounded-xl bg-green-100 px-4 py-3 text-green-700">
+                    {{ session('status') }}
+                </div>
+            @endif
+
+            @if ($errors->any())
+                <div class="rounded-xl bg-red-100 px-4 py-3 text-red-700">
+                    <p class="font-semibold">Terjadi kesalahan:</p>
+                    <ul class="mt-2 list-disc pl-5 text-sm">
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+
+            <main class="space-y-6">
+                {{ $slot }}
+            </main>
+        </div>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            document.querySelectorAll('[data-money-input]').forEach(container => {
+                const display = container.querySelector('[data-money-display]');
+                const hidden = container.querySelector('[data-money-hidden]');
+                const format = (value) => {
+                    if (value === '') {
+                        hidden.value = '';
+                        return '';
+                    }
+                    const numeric = value.replace(/[^0-9.,]/g, '').replace(/\./g, '').replace(/,/g, '.');
+                    const number = Number(numeric);
+                    if (Number.isNaN(number)) return '';
+                    hidden.value = number.toFixed(2);
+                    return new Intl.NumberFormat('id-ID', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(number);
+                };
+                display.addEventListener('input', () => {
+                    display.value = format(display.value);
+                });
+                display.addEventListener('blur', () => {
+                    display.value = format(display.value);
+                });
+            });
+
+            document.querySelectorAll('[data-modal]').forEach(modal => {
+                const trigger = modal.querySelector('[data-modal-trigger]');
+                const backdrop = modal.querySelector('[data-modal-backdrop]');
+                const closeButtons = modal.querySelectorAll('[data-modal-close]');
+
+                const open = () => backdrop.classList.remove('hidden');
+                const close = () => backdrop.classList.add('hidden');
+
+                trigger?.addEventListener('click', (event) => {
+                    event.preventDefault();
+                    open();
+                });
+
+                closeButtons.forEach(btn => btn.addEventListener('click', close));
+                backdrop?.addEventListener('click', (event) => {
+                    if (event.target === backdrop) {
+                        close();
+                    }
+                });
+            });
+        });
+    </script>
+</body>
+</html>

--- a/resources/views/components/layouts/guest.blade.php
+++ b/resources/views/components/layouts/guest.blade.php
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="id" class="h-full bg-slate-100">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ config('app.name', 'Tabungan') }}</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography,forms"></script>
+    <link rel="preconnect" href="https://fonts.bunny.net">
+    <link href="https://fonts.bunny.net/css?family=inter:400,500,600,700" rel="stylesheet" />
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+    </style>
+</head>
+<body class="flex min-h-full items-center justify-center p-6">
+    <div class="w-full max-w-md rounded-3xl bg-white p-8 shadow-xl">
+        <div class="mb-6 text-center">
+            <h1 class="text-2xl font-bold text-slate-900">{{ config('app.name', 'Tabungan') }}</h1>
+            <p class="text-sm text-slate-500">Masuk untuk mengelola tabungan Anda.</p>
+        </div>
+
+        @if (session('status'))
+            <div class="mb-4 rounded-xl bg-green-100 px-4 py-3 text-green-700">
+                {{ session('status') }}
+            </div>
+        @endif
+
+        @if ($errors->any())
+            <div class="mb-4 rounded-xl bg-red-100 px-4 py-3 text-red-700">
+                <ul class="list-disc pl-5 text-sm">
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+
+        {{ $slot }}
+    </div>
+</body>
+</html>

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -1,0 +1,20 @@
+@props([
+    'title' => 'Konfirmasi',
+])
+
+<div class="inline" data-modal>
+    <div data-modal-trigger>
+        {{ $trigger ?? $slot }}
+    </div>
+    <div class="fixed inset-0 z-40 hidden items-center justify-center bg-slate-900/60 p-4" data-modal-backdrop>
+        <div class="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+            <div class="flex items-start justify-between gap-4">
+                <h3 class="text-lg font-semibold text-slate-800">{{ $title }}</h3>
+                <button type="button" class="text-slate-400 hover:text-slate-600" data-modal-close>&times;</button>
+            </div>
+            <div class="mt-4 text-slate-600">
+                {{ $slot }}
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/components/table.blade.php
+++ b/resources/views/components/table.blade.php
@@ -1,0 +1,21 @@
+<div class="overflow-hidden rounded-2xl border border-slate-200">
+    <table class="min-w-full divide-y divide-slate-200">
+        <thead class="bg-slate-50">
+            <tr>
+                {{ $head ?? '' }}
+            </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-200 bg-white">
+            @if(isset($body))
+                {{ $body }}
+            @else
+                {{ $slot }}
+            @endif
+        </tbody>
+    </table>
+    @isset($empty)
+        <div class="p-8 text-center text-slate-500">
+            {{ $empty }}
+        </div>
+    @endisset
+</div>

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -1,0 +1,54 @@
+<x-layouts.app>
+    <div class="grid gap-6 md:grid-cols-2">
+        <x-card class="bg-gradient-to-br from-blue-600 to-blue-500 text-white">
+            <div class="flex flex-col gap-2">
+                <span class="text-sm uppercase tracking-wide text-blue-100">Saldo Tabungan</span>
+                <span class="text-4xl font-bold">{{ 'Rp '.number_format($account->balance, 2, ',', '.') }}</span>
+                <span class="text-sm text-blue-100">No. Rekening: {{ $account->account_number }}</span>
+            </div>
+        </x-card>
+        <x-card>
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-semibold text-slate-500">Transaksi bulan ini</p>
+                    <p class="mt-2 text-3xl font-bold text-slate-900">{{ $monthlyTotal }}</p>
+                </div>
+                <x-button as="a" href="{{ route('transactions.create') }}">Setor Dana</x-button>
+            </div>
+        </x-card>
+    </div>
+
+    <x-card>
+        <div class="mb-4 flex items-center justify-between">
+            <h2 class="text-lg font-semibold text-slate-900">Transaksi Terbaru</h2>
+            <a href="{{ route('transactions.index') }}" class="text-sm font-semibold text-blue-600 hover:underline">Lihat semua</a>
+        </div>
+        @if ($recentTransactions->isEmpty())
+            <div class="flex flex-col items-center justify-center gap-3 py-10 text-center text-slate-500">
+                <svg class="h-12 w-12 text-slate-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 5h18M3 12h18M3 19h18" />
+                </svg>
+                <p>Belum ada transaksi tercatat.</p>
+            </div>
+        @else
+            <div class="space-y-3">
+                @foreach ($recentTransactions as $transaction)
+                    <div class="flex items-center justify-between rounded-xl border border-slate-100 px-4 py-3">
+                        <div>
+                            <p class="font-semibold text-slate-900">
+                                {{ $transaction->type === \App\Models\Transaction::TYPE_DEPOSIT ? 'Setoran' : 'Penarikan' }}
+                            </p>
+                            <p class="text-sm text-slate-500">{{ $transaction->created_at->timezone('Asia/Jakarta')->translatedFormat('d F Y, H:i') }}</p>
+                        </div>
+                        <div class="text-right">
+                            <p class="font-semibold {{ $transaction->type === \App\Models\Transaction::TYPE_DEPOSIT ? 'text-green-600' : 'text-red-600' }}">
+                                {{ ($transaction->type === \App\Models\Transaction::TYPE_DEPOSIT ? '+' : '-') }}{{ 'Rp '.number_format($transaction->amount, 2, ',', '.') }}
+                            </p>
+                            <p class="text-xs text-slate-400">Saldo: {{ 'Rp '.number_format($transaction->running_balance, 2, ',', '.') }}</p>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        @endif
+    </x-card>
+</x-layouts.app>

--- a/resources/views/transactions/create.blade.php
+++ b/resources/views/transactions/create.blade.php
@@ -1,0 +1,29 @@
+<x-layouts.app>
+    <div class="grid gap-6 lg:grid-cols-2">
+        <x-card>
+            <h2 class="mb-4 text-xl font-semibold text-slate-900">Setor Dana</h2>
+            <form method="POST" action="{{ route('transactions.store') }}" class="space-y-4">
+                @csrf
+                <x-input-money name="amount" label="Nominal Setoran" value="{{ old('amount', 100000) }}" />
+                <div>
+                    <label for="note" class="mb-1 block text-sm font-medium text-slate-600">Catatan (opsional)</label>
+                    <textarea id="note" name="note" rows="3" class="w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200" placeholder="Contoh: Setoran gaji bulan ini">{{ old('note') }}</textarea>
+                </div>
+                <x-button type="submit" class="w-full justify-center">Simpan Setoran</x-button>
+            </form>
+        </x-card>
+
+        <x-card>
+            <h2 class="mb-4 text-xl font-semibold text-slate-900">Tarik Dana</h2>
+            <form method="POST" action="{{ route('transactions.withdraw') }}" class="space-y-4">
+                @csrf
+                <x-input-money name="amount" label="Nominal Penarikan" value="{{ old('amount') }}" />
+                <div>
+                    <label for="withdraw-note" class="mb-1 block text-sm font-medium text-slate-600">Catatan (opsional)</label>
+                    <textarea id="withdraw-note" name="note" rows="3" class="w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200" placeholder="Contoh: Penarikan kebutuhan"></textarea>
+                </div>
+                <x-button type="submit" class="w-full justify-center" variant="secondary">Simpan Penarikan</x-button>
+            </form>
+        </x-card>
+    </div>
+</x-layouts.app>

--- a/resources/views/transactions/index.blade.php
+++ b/resources/views/transactions/index.blade.php
@@ -1,0 +1,86 @@
+<x-layouts.app>
+    <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div>
+            <h2 class="text-2xl font-bold text-slate-900">Riwayat Transaksi</h2>
+            <p class="text-sm text-slate-500">Saldo saat ini: <span class="font-semibold">{{ 'Rp '.number_format($account->balance, 2, ',', '.') }}</span></p>
+        </div>
+        <div>
+            <a href="{{ route('transactions.create') }}" class="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-4 py-2 font-semibold text-white shadow hover:bg-blue-700">
+                + Transaksi Baru
+            </a>
+        </div>
+    </div>
+
+    <x-card>
+        <form method="GET" action="{{ route('transactions.index') }}" class="grid gap-4 md:grid-cols-4">
+            <div>
+                <label class="mb-1 block text-sm font-medium text-slate-600">Tipe</label>
+                <select name="type" class="w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200">
+                    <option value="">Semua</option>
+                    <option value="deposit" @selected(($filters['type'] ?? '') === 'deposit')>Setoran</option>
+                    <option value="withdrawal" @selected(($filters['type'] ?? '') === 'withdrawal')>Penarikan</option>
+                </select>
+            </div>
+            <div>
+                <label class="mb-1 block text-sm font-medium text-slate-600">Dari</label>
+                <input type="date" name="from" value="{{ $filters['from'] ?? '' }}" class="w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200">
+            </div>
+            <div>
+                <label class="mb-1 block text-sm font-medium text-slate-600">Sampai</label>
+                <input type="date" name="to" value="{{ $filters['to'] ?? '' }}" class="w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200">
+            </div>
+            <div class="flex items-end gap-2">
+                <x-button type="submit" class="flex-1 justify-center">Terapkan</x-button>
+                <x-button href="{{ route('transactions.index') }}" variant="secondary">Reset</x-button>
+            </div>
+        </form>
+    </x-card>
+
+    <x-card>
+        @if ($transactions->isEmpty())
+            <div class="flex flex-col items-center justify-center gap-3 py-10 text-center text-slate-500">
+                <svg class="h-12 w-12 text-slate-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 5h18M3 12h18M3 19h18" />
+                </svg>
+                <p>Tidak ada transaksi pada rentang ini.</p>
+            </div>
+        @else
+            <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-slate-200">
+                    <thead class="bg-slate-50">
+                        <tr>
+                            <th class="px-4 py-3 text-left text-sm font-semibold text-slate-600">Tanggal</th>
+                            <th class="px-4 py-3 text-left text-sm font-semibold text-slate-600">Tipe</th>
+                            <th class="px-4 py-3 text-right text-sm font-semibold text-slate-600">Nominal</th>
+                            <th class="px-4 py-3 text-right text-sm font-semibold text-slate-600">Saldo Berjalan</th>
+                            <th class="px-4 py-3 text-right text-sm font-semibold text-slate-600">Aksi</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-slate-100">
+                        @foreach ($transactions as $transaction)
+                            <tr class="hover:bg-slate-50">
+                                <td class="px-4 py-3 text-sm text-slate-600">{{ $transaction->created_at->timezone('Asia/Jakarta')->translatedFormat('d F Y, H:i') }}</td>
+                                <td class="px-4 py-3 text-sm text-slate-600">
+                                    <x-badge :variant="$transaction->type === 'deposit' ? 'success' : 'warning'">
+                                        {{ $transaction->type === 'deposit' ? 'Setoran' : 'Penarikan' }}
+                                    </x-badge>
+                                </td>
+                                <td class="px-4 py-3 text-right text-sm font-semibold {{ $transaction->type === 'deposit' ? 'text-green-600' : 'text-red-600' }}">
+                                    {{ ($transaction->type === 'deposit' ? '+' : '-') }}{{ 'Rp '.number_format($transaction->amount, 2, ',', '.') }}
+                                </td>
+                                <td class="px-4 py-3 text-right text-sm text-slate-600">{{ 'Rp '.number_format($transaction->running_balance, 2, ',', '.') }}</td>
+                                <td class="px-4 py-3 text-right text-sm">
+                                    <a href="{{ route('transactions.show', $transaction) }}" class="font-semibold text-blue-600 hover:underline">Detail</a>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="mt-6">
+                {{ $transactions->links() }}
+            </div>
+        @endif
+    </x-card>
+</x-layouts.app>

--- a/resources/views/transactions/receipt.blade.php
+++ b/resources/views/transactions/receipt.blade.php
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+    <meta charset="utf-8">
+    <title>Struk Transaksi {{ $transaction->receipt_number }}</title>
+    <style>
+        body { font-family: 'Inter', sans-serif; background: #f7fafc; color: #1f2937; margin: 0; padding: 0; }
+        .receipt { max-width: 560px; margin: 0 auto; background: #fff; padding: 32px; border-radius: 24px; box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08); }
+        .header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
+        .logo { font-size: 20px; font-weight: 700; color: #1d4ed8; }
+        .badge { padding: 6px 12px; border-radius: 999px; font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; }
+        .badge.deposit { background: #dcfce7; color: #15803d; }
+        .badge.withdrawal { background: #fef3c7; color: #b45309; }
+        dl { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+        dt { font-size: 12px; font-weight: 600; color: #64748b; text-transform: uppercase; letter-spacing: 0.05em; }
+        dd { font-size: 16px; font-weight: 600; color: #1f2937; margin: 4px 0 0; }
+        .note { margin-top: 20px; padding: 16px; border-radius: 16px; background: #f8fafc; font-size: 14px; color: #334155; }
+        .footer { margin-top: 24px; display: flex; justify-content: space-between; align-items: flex-end; }
+        .qr { display: grid; grid-template-columns: repeat(10, 6px); grid-auto-rows: 6px; gap: 1px; padding: 6px; background: #000; border-radius: 8px; }
+        .qr span { background: #fff; border-radius: 1px; }
+        .qr span.filled { background: #000; }
+        @media print {
+            body { background: #fff; }
+            .receipt { box-shadow: none; border-radius: 0; }
+        }
+    </style>
+</head>
+<body>
+@php
+    $hash = md5($transaction->receipt_number);
+    $bits = [];
+    for ($i = 0; $i < 100; $i++) {
+        $bits[] = intval($hash[$i % strlen($hash)], 16) % 2 === 0;
+    }
+@endphp
+<div class="receipt">
+    <div class="header">
+        <div>
+            <div class="logo">{{ config('app.name', 'Tabungan') }}</div>
+            <div style="font-size:12px; color:#64748b;">Struk Transaksi</div>
+        </div>
+        <div class="badge {{ $transaction->type }}">
+            {{ $transaction->type === 'deposit' ? 'Setoran' : 'Penarikan' }}
+        </div>
+    </div>
+    <div style="margin-bottom: 24px;">
+        <div style="font-size:28px; font-weight:700; color:#111827;">{{ 'Rp '.number_format($transaction->amount, 2, ',', '.') }}</div>
+        <div style="font-size:14px; color:#64748b;">Saldo setelah transaksi: {{ 'Rp '.number_format($transaction->running_balance, 2, ',', '.') }}</div>
+    </div>
+    <dl>
+        <div>
+            <dt>Nomor Struk</dt>
+            <dd>{{ $transaction->receipt_number }}</dd>
+        </div>
+        <div>
+            <dt>Tanggal</dt>
+            <dd>{{ $transaction->created_at->timezone('Asia/Jakarta')->translatedFormat('d F Y, H:i') }} WIB</dd>
+        </div>
+        <div>
+            <dt>Nama Nasabah</dt>
+            <dd>{{ $user->name }}</dd>
+        </div>
+        <div>
+            <dt>Email</dt>
+            <dd>{{ $user->email }}</dd>
+        </div>
+        <div>
+            <dt>No. Rekening</dt>
+            <dd>{{ $account->account_number }}</dd>
+        </div>
+        <div>
+            <dt>Jenis Transaksi</dt>
+            <dd>{{ $transaction->type === 'deposit' ? 'Setoran' : 'Penarikan' }}</dd>
+        </div>
+    </dl>
+
+    @if ($transaction->note)
+        <div class="note">
+            <strong>Catatan:</strong>
+            <div>{{ $transaction->note }}</div>
+        </div>
+    @endif
+
+    <div class="footer">
+        <div>
+            <div style="font-size:12px; color:#94a3b8;">Dicetak pada {{ now('Asia/Jakarta')->translatedFormat('d F Y, H:i') }} WIB</div>
+            <div style="font-size:12px; color:#64748b;">Terima kasih telah menggunakan layanan kami.</div>
+        </div>
+        <div class="qr">
+            @foreach ($bits as $bit)
+                <span class="{{ $bit ? 'filled' : '' }}"></span>
+            @endforeach
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/resources/views/transactions/show.blade.php
+++ b/resources/views/transactions/show.blade.php
@@ -1,0 +1,56 @@
+<x-layouts.app>
+    <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+            <h2 class="text-2xl font-bold text-slate-900">Detail Transaksi</h2>
+            <p class="text-sm text-slate-500">Nomor struk: {{ $transaction->receipt_number }}</p>
+        </div>
+        <div class="flex gap-2">
+            <x-button href="{{ route('transactions.receipt', $transaction) }}" target="_blank">Cetak Struk</x-button>
+            <x-button href="{{ route('transactions.index') }}" variant="secondary">Kembali</x-button>
+        </div>
+    </div>
+
+    <x-card>
+        <dl class="grid gap-4 md:grid-cols-2">
+            <div>
+                <dt class="text-sm font-medium text-slate-500">Jenis Transaksi</dt>
+                <dd class="mt-1 text-lg font-semibold text-slate-900">
+                    {{ $transaction->type === 'deposit' ? 'Setoran' : 'Penarikan' }}
+                </dd>
+            </div>
+            <div>
+                <dt class="text-sm font-medium text-slate-500">Tanggal</dt>
+                <dd class="mt-1 text-lg font-semibold text-slate-900">
+                    {{ $transaction->created_at->timezone('Asia/Jakarta')->translatedFormat('d F Y, H:i') }} WIB
+                </dd>
+            </div>
+            <div>
+                <dt class="text-sm font-medium text-slate-500">Nominal</dt>
+                <dd class="mt-1 text-lg font-semibold {{ $transaction->type === 'deposit' ? 'text-green-600' : 'text-red-600' }}">
+                    {{ $transaction->type === 'deposit' ? '+' : '-' }}{{ 'Rp '.number_format($transaction->amount, 2, ',', '.') }}
+                </dd>
+            </div>
+            <div>
+                <dt class="text-sm font-medium text-slate-500">Saldo Setelah Transaksi</dt>
+                <dd class="mt-1 text-lg font-semibold text-slate-900">
+                    {{ 'Rp '.number_format($transaction->running_balance, 2, ',', '.') }}
+                </dd>
+            </div>
+            <div>
+                <dt class="text-sm font-medium text-slate-500">Pemilik Tabungan</dt>
+                <dd class="mt-1 text-lg font-semibold text-slate-900">{{ $transaction->savingsAccount->user->name }}</dd>
+            </div>
+            <div>
+                <dt class="text-sm font-medium text-slate-500">No. Rekening</dt>
+                <dd class="mt-1 text-lg font-semibold text-slate-900">{{ $transaction->savingsAccount->account_number }}</dd>
+            </div>
+        </dl>
+
+        @if ($transaction->note)
+            <div class="mt-6 rounded-xl bg-slate-50 p-4">
+                <h3 class="text-sm font-semibold text-slate-600">Catatan</h3>
+                <p class="mt-2 text-slate-700">{{ $transaction->note }}</p>
+            </div>
+        @endif
+    </x-card>
+</x-layouts.app>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,32 @@
 <?php
 
+use App\Http\Controllers\AuthController;
+use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\TransactionController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
+Route::middleware('guest')->group(function () {
+    Route::get('/login', [AuthController::class, 'showLogin'])->name('login');
+    Route::post('/login', [AuthController::class, 'login']);
+    Route::get('/register', [AuthController::class, 'showRegister'])->name('register');
+    Route::post('/register', [AuthController::class, 'register']);
+});
+
+Route::post('/logout', [AuthController::class, 'logout'])->middleware('auth')->name('logout');
+
+Route::get('/', DashboardController::class)
+    ->middleware(['auth'])
+    ->name('dashboard');
+
+Route::middleware('auth')->group(function () {
+    Route::get('/transactions', [TransactionController::class, 'index'])->name('transactions.index');
+    Route::get('/transactions/create', [TransactionController::class, 'create'])->name('transactions.create');
+    Route::post('/transactions', [TransactionController::class, 'store'])
+        ->middleware('throttle:5,1')
+        ->name('transactions.store');
+    Route::post('/transactions/withdraw', [TransactionController::class, 'storeWithdrawal'])
+        ->middleware('throttle:5,1')
+        ->name('transactions.withdraw');
+    Route::get('/transactions/{transaction}', [TransactionController::class, 'show'])->name('transactions.show');
+    Route::get('/transactions/{transaction}/receipt', [TransactionController::class, 'receipt'])->name('transactions.receipt');
 });

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/Feature/TransactionTest.php
+++ b/tests/Feature/TransactionTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TransactionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_creates_savings_account_when_user_accesses_dashboard(): void
+    {
+        $user = User::factory()->create();
+
+        $this->assertNull($user->savingsAccount);
+
+        $response = $this->actingAs($user)->get('/');
+
+        $response->assertOk();
+        $user->refresh();
+
+        $this->assertNotNull($user->savingsAccount);
+        $this->assertSame('0.00', $user->savingsAccount->balance);
+    }
+
+    public function test_it_stores_deposit_and_updates_balance(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('/transactions', [
+            'amount' => 150000,
+            'note' => 'Setoran awal',
+        ]);
+
+        $response->assertRedirect();
+
+        $account = $user->fresh()->savingsAccount;
+
+        $this->assertSame('150000.00', $account->balance);
+        $this->assertCount(1, $account->transactions);
+        $this->assertSame('150000.00', $account->transactions->first()->running_balance);
+    }
+
+    public function test_it_rejects_withdrawal_when_balance_is_insufficient(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->post('/transactions', [
+            'amount' => 50000,
+        ]);
+
+        $response = $this->actingAs($user)->post('/transactions/withdraw', [
+            'amount' => 100000,
+        ]);
+
+        $response->assertSessionHasErrors('amount');
+    }
+
+    public function test_it_blocks_access_to_transactions_owned_by_other_users(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+
+        $this->actingAs($user)->post('/transactions', [
+            'amount' => 75000,
+        ]);
+
+        $transaction = $user->fresh()->savingsAccount->transactions->first();
+
+        $this->actingAs($other)
+            ->get(route('transactions.show', $transaction))
+            ->assertForbidden();
+    }
+
+    public function test_receipt_endpoint_returns_valid_response(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->post('/transactions', [
+            'amount' => 125000,
+        ]);
+
+        $transaction = $user->fresh()->savingsAccount->transactions->first();
+
+        $response = $this->actingAs($user)->get(route('transactions.receipt', $transaction));
+
+        $response->assertOk();
+        $contentType = $response->headers->get('content-type');
+
+        $this->assertNotNull($contentType);
+        $this->assertMatchesRegularExpression('/pdf|text\\/html/', $contentType);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,5 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use CreatesApplication;
 }


### PR DESCRIPTION
## Summary
- rely on route-level middleware registration instead of duplicating checks inside controllers
- convert transaction feature tests from Pest-style closures to a PHPUnit test case and remove Pest bootstrap

## Testing
- `./vendor/bin/phpunit` *(fails: vendor directory not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e357cb5e6c8323b52c2c494a7ac371