### PR TITLE
Move middleware registration to routes

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -15,7 +15,6 @@ class AuthController extends Controller
 {
     public function __construct(protected CreateSavingsAccountForUser $createSavingsAccountForUser)
     {
-        $this->middleware('guest')->only(['showLogin', 'showRegister']);
     }
 
     public function showLogin(): View

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -11,7 +11,6 @@ class DashboardController extends Controller
     public function __construct(
         protected CreateSavingsAccountForUser $createSavingsAccountForUser
     ) {
-        $this->middleware('auth');
     }
 
     public function __invoke(Request $request): View

--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -24,7 +24,6 @@ class TransactionController extends Controller
         protected GenerateReceiptPdf $generateReceiptPdf,
         protected CreateSavingsAccountForUser $createSavingsAccountForUser,
     ) {
-        $this->middleware('auth');
     }
 
     public function index(Request $request): View


### PR DESCRIPTION
## Summary
- remove controller-level middleware assignments so middleware is managed via route definitions

## Testing
- php artisan test *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_b_68e360adf05c832385a12cd56db9a551